### PR TITLE
Update AWS cloudwatch preset

### DIFF
--- a/src/presets.ts
+++ b/src/presets.ts
@@ -74,7 +74,7 @@ export default (): void => {
       maxValue: 31,
     },
     months: {
-      minValue: 0,
+      minValue: 1,
       maxValue: 12,
     },
     daysOfWeek: {


### PR DESCRIPTION
Small change to reflect the AWS docs better.

According to the [AWS CloudWatch docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html), the minimum for `months` is 1 whereas the preset here is set to `0`.

