### PR TITLE
Make cron validate x100 faster

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,7 @@ import checkDaysOfMonth from './fieldCheckers/dayOfMonthChecker'
 import checkMonths from './fieldCheckers/monthChecker'
 import checkDaysOfWeek from './fieldCheckers/dayOfWeekChecker'
 import checkYears from './fieldCheckers/yearChecker'
-import {
-  getOptionPreset,
-  registerOptionPreset,
-  validateOptions,
-} from './option'
+import { validateOptions } from './option'
 import { InputOptions, Options } from './types'
 
 export interface CronData {

--- a/src/option.ts
+++ b/src/option.ts
@@ -150,6 +150,13 @@ export const registerOptionPreset = (
     recursive: true,
   })
 }
+function loadPresets() {
+  for (let index = 0; index < presets.length; index += 1) {
+    const { name, preset } = presets[index];
+    registerOptionPreset(name, preset)
+  }
+}
+loadPresets();
 
 function presetToOptionsSchema(preset: OptionPreset) {
   return yup
@@ -327,9 +334,6 @@ export const validateOptions = (
   inputOptions: InputOptions
 ): Result<Options, string[]> => {
   try {
-    // load default presets
-    presets()
-
     let preset: OptionPreset
     if (inputOptions.preset) {
       if (typeof inputOptions.preset === 'string') {

--- a/src/option.ts
+++ b/src/option.ts
@@ -151,6 +151,178 @@ export const registerOptionPreset = (
   })
 }
 
+function presetToOptionsSchema(preset: OptionPreset) {
+  return yup
+  .object({
+    presetId: yup.string().required(),
+    preset: optionPresetSchema.required(),
+    useSeconds: yup.boolean().required(),
+    useYears: yup.boolean().required(),
+    useAliases: yup.boolean(),
+    useBlankDay: yup.boolean().required(),
+    allowOnlyOneBlankDayField: yup.boolean().required(),
+    allowStepping: yup.boolean(),
+    mustHaveBlankDayField: yup.boolean(),
+    useLastDayOfMonth: yup.boolean(),
+    useLastDayOfWeek: yup.boolean(),
+    useNearestWeekday: yup.boolean(),
+    useNthWeekdayOfMonth: yup.boolean(),
+    seconds: yup
+      .object({
+        lowerLimit: yup
+          .number()
+          .min(preset.seconds.minValue)
+          .max(preset.seconds.maxValue),
+        upperLimit: yup
+          .number()
+          .min(preset.seconds.minValue)
+          .max(preset.seconds.maxValue),
+      })
+      .required(),
+    minutes: yup
+      .object({
+        lowerLimit: yup
+          .number()
+          .min(preset.minutes.minValue)
+          .max(preset.minutes.maxValue),
+        upperLimit: yup
+          .number()
+          .min(preset.minutes.minValue)
+          .max(preset.minutes.maxValue),
+      })
+      .required(),
+    hours: yup
+      .object({
+        lowerLimit: yup
+          .number()
+          .min(preset.hours.minValue)
+          .max(preset.hours.maxValue),
+        upperLimit: yup
+          .number()
+          .min(preset.hours.minValue)
+          .max(preset.hours.maxValue),
+      })
+      .required(),
+    daysOfMonth: yup
+      .object({
+        lowerLimit: yup
+          .number()
+          .min(preset.daysOfMonth.minValue)
+          .max(preset.daysOfMonth.maxValue),
+        upperLimit: yup
+          .number()
+          .min(preset.daysOfMonth.minValue)
+          .max(preset.daysOfMonth.maxValue),
+      })
+      .required(),
+    months: yup
+      .object({
+        lowerLimit: yup
+          .number()
+          .min(preset.months.minValue)
+          .max(preset.months.maxValue),
+        upperLimit: yup
+          .number()
+          .min(preset.months.minValue)
+          .max(preset.months.maxValue),
+      })
+      .required(),
+    daysOfWeek: yup
+      .object({
+        lowerLimit: yup
+          .number()
+          .min(preset.daysOfWeek.minValue)
+          .max(preset.daysOfWeek.maxValue),
+        upperLimit: yup
+          .number()
+          .min(preset.daysOfWeek.minValue)
+          .max(preset.daysOfWeek.maxValue),
+      })
+      .required(),
+    years: yup
+      .object({
+        lowerLimit: yup
+          .number()
+          .min(preset.years.minValue)
+          .max(preset.years.maxValue),
+        upperLimit: yup
+          .number()
+          .min(preset.years.minValue)
+          .max(preset.years.maxValue),
+      })
+      .required(),
+  })
+  .required()
+}
+
+function presetToOptions(preset: OptionPreset, override?: InputOptions["override"]) {
+
+  const unvalidatedConfig = {
+    presetId: preset.presetId,
+    preset,
+    ...{
+      useSeconds: preset.useSeconds,
+      useYears: preset.useYears,
+      useAliases: preset.useAliases ?? false,
+      useBlankDay: preset.useBlankDay,
+      allowOnlyOneBlankDayField: preset.allowOnlyOneBlankDayField,
+      allowStepping: preset.allowStepping ?? true,
+      mustHaveBlankDayField: preset.mustHaveBlankDayField ?? false,
+      useLastDayOfMonth: preset.useLastDayOfMonth ?? false,
+      useLastDayOfWeek: preset.useLastDayOfWeek ?? false,
+      useNearestWeekday: preset.useNearestWeekday ?? false,
+      useNthWeekdayOfMonth: preset.useNthWeekdayOfMonth ?? false,
+      seconds: {
+        lowerLimit: preset.seconds.lowerLimit ?? preset.seconds.minValue,
+        upperLimit: preset.seconds.upperLimit ?? preset.seconds.maxValue,
+      },
+      minutes: {
+        lowerLimit: preset.minutes.lowerLimit ?? preset.minutes.minValue,
+        upperLimit: preset.minutes.upperLimit ?? preset.minutes.maxValue,
+      },
+      hours: {
+        lowerLimit: preset.hours.lowerLimit ?? preset.hours.minValue,
+        upperLimit: preset.hours.upperLimit ?? preset.hours.maxValue,
+      },
+      daysOfMonth: {
+        lowerLimit:
+          preset.daysOfMonth.lowerLimit ?? preset.daysOfMonth.minValue,
+        upperLimit:
+          preset.daysOfMonth.upperLimit ?? preset.daysOfMonth.maxValue,
+      },
+      months: {
+        lowerLimit: preset.months.lowerLimit ?? preset.months.minValue,
+        upperLimit: preset.months.upperLimit ?? preset.months.maxValue,
+      },
+      daysOfWeek: {
+        lowerLimit:
+          preset.daysOfWeek.lowerLimit ?? preset.daysOfWeek.minValue,
+        upperLimit:
+          preset.daysOfWeek.upperLimit ?? preset.daysOfWeek.maxValue,
+      },
+      years: {
+        lowerLimit: preset.years.lowerLimit ?? preset.years.minValue,
+        upperLimit: preset.years.upperLimit ?? preset.years.maxValue,
+      },
+    },
+    ...override,
+  }
+
+  const optionsSchema = presetToOptionsSchema(preset);
+
+  const validatedConfig: Options = optionsSchema.validateSync(
+    unvalidatedConfig,
+    {
+      strict: false,
+      abortEarly: false,
+      stripUnknown: true,
+      recursive: true,
+    }
+  )
+
+  return validatedConfig
+}
+
 export const validateOptions = (
   inputOptions: InputOptions
 ): Result<Options, string[]> => {
@@ -173,170 +345,8 @@ export const validateOptions = (
       preset = optionPresets.default
     }
 
-    const unvalidatedConfig = {
-      presetId: preset.presetId,
-      preset,
-      ...{
-        useSeconds: preset.useSeconds,
-        useYears: preset.useYears,
-        useAliases: preset.useAliases ?? false,
-        useBlankDay: preset.useBlankDay,
-        allowOnlyOneBlankDayField: preset.allowOnlyOneBlankDayField,
-        allowStepping: preset.allowStepping ?? true,
-        mustHaveBlankDayField: preset.mustHaveBlankDayField ?? false,
-        useLastDayOfMonth: preset.useLastDayOfMonth ?? false,
-        useLastDayOfWeek: preset.useLastDayOfWeek ?? false,
-        useNearestWeekday: preset.useNearestWeekday ?? false,
-        useNthWeekdayOfMonth: preset.useNthWeekdayOfMonth ?? false,
-        seconds: {
-          lowerLimit: preset.seconds.lowerLimit ?? preset.seconds.minValue,
-          upperLimit: preset.seconds.upperLimit ?? preset.seconds.maxValue,
-        },
-        minutes: {
-          lowerLimit: preset.minutes.lowerLimit ?? preset.minutes.minValue,
-          upperLimit: preset.minutes.upperLimit ?? preset.minutes.maxValue,
-        },
-        hours: {
-          lowerLimit: preset.hours.lowerLimit ?? preset.hours.minValue,
-          upperLimit: preset.hours.upperLimit ?? preset.hours.maxValue,
-        },
-        daysOfMonth: {
-          lowerLimit:
-            preset.daysOfMonth.lowerLimit ?? preset.daysOfMonth.minValue,
-          upperLimit:
-            preset.daysOfMonth.upperLimit ?? preset.daysOfMonth.maxValue,
-        },
-        months: {
-          lowerLimit: preset.months.lowerLimit ?? preset.months.minValue,
-          upperLimit: preset.months.upperLimit ?? preset.months.maxValue,
-        },
-        daysOfWeek: {
-          lowerLimit:
-            preset.daysOfWeek.lowerLimit ?? preset.daysOfWeek.minValue,
-          upperLimit:
-            preset.daysOfWeek.upperLimit ?? preset.daysOfWeek.maxValue,
-        },
-        years: {
-          lowerLimit: preset.years.lowerLimit ?? preset.years.minValue,
-          upperLimit: preset.years.upperLimit ?? preset.years.maxValue,
-        },
-      },
-      ...inputOptions.override,
-    }
-
-    const optionsSchema = yup
-      .object({
-        presetId: yup.string().required(),
-        preset: optionPresetSchema.required(),
-        useSeconds: yup.boolean().required(),
-        useYears: yup.boolean().required(),
-        useAliases: yup.boolean(),
-        useBlankDay: yup.boolean().required(),
-        allowOnlyOneBlankDayField: yup.boolean().required(),
-        allowStepping: yup.boolean(),
-        mustHaveBlankDayField: yup.boolean(),
-        useLastDayOfMonth: yup.boolean(),
-        useLastDayOfWeek: yup.boolean(),
-        useNearestWeekday: yup.boolean(),
-        useNthWeekdayOfMonth: yup.boolean(),
-        seconds: yup
-          .object({
-            lowerLimit: yup
-              .number()
-              .min(preset.seconds.minValue)
-              .max(preset.seconds.maxValue),
-            upperLimit: yup
-              .number()
-              .min(preset.seconds.minValue)
-              .max(preset.seconds.maxValue),
-          })
-          .required(),
-        minutes: yup
-          .object({
-            lowerLimit: yup
-              .number()
-              .min(preset.minutes.minValue)
-              .max(preset.minutes.maxValue),
-            upperLimit: yup
-              .number()
-              .min(preset.minutes.minValue)
-              .max(preset.minutes.maxValue),
-          })
-          .required(),
-        hours: yup
-          .object({
-            lowerLimit: yup
-              .number()
-              .min(preset.hours.minValue)
-              .max(preset.hours.maxValue),
-            upperLimit: yup
-              .number()
-              .min(preset.hours.minValue)
-              .max(preset.hours.maxValue),
-          })
-          .required(),
-        daysOfMonth: yup
-          .object({
-            lowerLimit: yup
-              .number()
-              .min(preset.daysOfMonth.minValue)
-              .max(preset.daysOfMonth.maxValue),
-            upperLimit: yup
-              .number()
-              .min(preset.daysOfMonth.minValue)
-              .max(preset.daysOfMonth.maxValue),
-          })
-          .required(),
-        months: yup
-          .object({
-            lowerLimit: yup
-              .number()
-              .min(preset.months.minValue)
-              .max(preset.months.maxValue),
-            upperLimit: yup
-              .number()
-              .min(preset.months.minValue)
-              .max(preset.months.maxValue),
-          })
-          .required(),
-        daysOfWeek: yup
-          .object({
-            lowerLimit: yup
-              .number()
-              .min(preset.daysOfWeek.minValue)
-              .max(preset.daysOfWeek.maxValue),
-            upperLimit: yup
-              .number()
-              .min(preset.daysOfWeek.minValue)
-              .max(preset.daysOfWeek.maxValue),
-          })
-          .required(),
-        years: yup
-          .object({
-            lowerLimit: yup
-              .number()
-              .min(preset.years.minValue)
-              .max(preset.years.maxValue),
-            upperLimit: yup
-              .number()
-              .min(preset.years.minValue)
-              .max(preset.years.maxValue),
-          })
-          .required(),
-      })
-      .required()
-
-    const validatedConfig: Options = optionsSchema.validateSync(
-      unvalidatedConfig,
-      {
-        strict: false,
-        abortEarly: false,
-        stripUnknown: true,
-        recursive: true,
-      }
-    )
-
-    return valid(validatedConfig)
+    const options = presetToOptions(preset, inputOptions.override);
+    return valid(options);
   } catch (validationError) {
     return err((validationError as ValidationError).errors)
   }

--- a/src/option.ts
+++ b/src/option.ts
@@ -158,6 +158,13 @@ function loadPresets() {
 }
 loadPresets();
 
+type OptionsCacheKey = string;
+const optionsCache: Map<OptionsCacheKey, Options> = new Map();
+
+function toOptionsCacheKey(presetId: string, override?: InputOptions["override"]) {
+  return presetId + (JSON.stringify(override) ?? "");
+}
+
 function presetToOptionsSchema(preset: OptionPreset) {
   return yup
   .object({
@@ -349,7 +356,13 @@ export const validateOptions = (
       preset = optionPresets.default
     }
 
+    const cacheKey = toOptionsCacheKey(preset.presetId, inputOptions.override);
+
+    const cachedOptions = optionsCache.get(cacheKey);
+    if (cachedOptions) return valid(cachedOptions);
+
     const options = presetToOptions(preset, inputOptions.override);
+    optionsCache.set(cacheKey, options);
     return valid(options);
   } catch (validationError) {
     return err((validationError as ValidationError).errors)

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,132 +1,137 @@
-import { registerOptionPreset } from './option'
-
-export default (): void => {
-  registerOptionPreset('npm-node-cron', {
-    // https://github.com/kelektiv/node-cron
-    presetId: 'npm-node-cron',
-    useSeconds: true,
-    useYears: false,
-    useAliases: true,
-    useBlankDay: false,
-    allowOnlyOneBlankDayField: false,
-    mustHaveBlankDayField: false,
-    useLastDayOfMonth: false,
-    useLastDayOfWeek: false,
-    useNearestWeekday: false,
-    useNthWeekdayOfMonth: false,
-    seconds: {
-      minValue: 0,
-      maxValue: 59,
-    },
-    minutes: {
-      minValue: 0,
-      maxValue: 59,
-    },
-    hours: {
-      minValue: 0,
-      maxValue: 23,
-    },
-    daysOfMonth: {
-      minValue: 1,
-      maxValue: 31,
-    },
-    months: {
-      minValue: 0,
-      maxValue: 11,
-    },
-    daysOfWeek: {
-      minValue: 0,
-      maxValue: 6,
-    },
-    years: {
-      minValue: 1970,
-      maxValue: 2099,
-    },
-  })
-
-  registerOptionPreset('aws-cloud-watch', {
-    // https://docs.aws.amazon.com/de_de/AmazonCloudWatch/latest/events/ScheduledEvents.html
-    presetId: 'aws-cloud-watch',
-    useSeconds: false,
-    useYears: true,
-    useAliases: true,
-    useBlankDay: true,
-    allowOnlyOneBlankDayField: true,
-    mustHaveBlankDayField: true,
-    useLastDayOfMonth: true,
-    useLastDayOfWeek: true,
-    useNearestWeekday: true,
-    useNthWeekdayOfMonth: true,
-    seconds: {
-      minValue: 0,
-      maxValue: 59,
-    },
-    minutes: {
-      minValue: 0,
-      maxValue: 59,
-    },
-    hours: {
-      minValue: 0,
-      maxValue: 23,
-    },
-    daysOfMonth: {
-      minValue: 1,
-      maxValue: 31,
-    },
-    months: {
-      minValue: 1,
-      maxValue: 12,
-    },
-    daysOfWeek: {
-      minValue: 1,
-      maxValue: 7,
-    },
-    years: {
-      minValue: 1970,
-      maxValue: 2199,
-    },
-  })
-
-  registerOptionPreset('npm-cron-schedule', {
-    // https://github.com/P4sca1/cron-schedule
-    presetId: 'npm-cron-schedule',
-    useSeconds: true,
-    useYears: false,
-    useAliases: true,
-    useBlankDay: false,
-    allowOnlyOneBlankDayField: false,
-    mustHaveBlankDayField: false,
-    useLastDayOfMonth: false,
-    useLastDayOfWeek: false,
-    useNearestWeekday: false,
-    useNthWeekdayOfMonth: false,
-    seconds: {
-      minValue: 0,
-      maxValue: 59,
-    },
-    minutes: {
-      minValue: 0,
-      maxValue: 59,
-    },
-    hours: {
-      minValue: 0,
-      maxValue: 23,
-    },
-    daysOfMonth: {
-      minValue: 1,
-      maxValue: 31,
-    },
-    months: {
-      minValue: 1,
-      maxValue: 12,
-    },
-    daysOfWeek: {
-      minValue: 0,
-      maxValue: 7,
-    },
-    years: {
-      minValue: 1970,
-      maxValue: 2099,
-    },
-  })
-}
+export default [
+  {
+    name: "npm-node-cron",
+    preset: {
+      // https://github.com/kelektiv/node-cron
+      presetId: 'npm-node-cron',
+      useSeconds: true,
+      useYears: false,
+      useAliases: true,
+      useBlankDay: false,
+      allowOnlyOneBlankDayField: false,
+      mustHaveBlankDayField: false,
+      useLastDayOfMonth: false,
+      useLastDayOfWeek: false,
+      useNearestWeekday: false,
+      useNthWeekdayOfMonth: false,
+      seconds: {
+        minValue: 0,
+        maxValue: 59,
+      },
+      minutes: {
+        minValue: 0,
+        maxValue: 59,
+      },
+      hours: {
+        minValue: 0,
+        maxValue: 23,
+      },
+      daysOfMonth: {
+        minValue: 1,
+        maxValue: 31,
+      },
+      months: {
+        minValue: 0,
+        maxValue: 11,
+      },
+      daysOfWeek: {
+        minValue: 0,
+        maxValue: 6,
+      },
+      years: {
+        minValue: 1970,
+        maxValue: 2099,
+      },
+    }
+  },
+  {
+    name: "aws-cloud-watch",
+    preset: {
+      // https://docs.aws.amazon.com/de_de/AmazonCloudWatch/latest/events/ScheduledEvents.html
+      presetId: 'aws-cloud-watch',
+      useSeconds: false,
+      useYears: true,
+      useAliases: true,
+      useBlankDay: true,
+      allowOnlyOneBlankDayField: true,
+      mustHaveBlankDayField: true,
+      useLastDayOfMonth: true,
+      useLastDayOfWeek: true,
+      useNearestWeekday: true,
+      useNthWeekdayOfMonth: true,
+      seconds: {
+        minValue: 0,
+        maxValue: 59,
+      },
+      minutes: {
+        minValue: 0,
+        maxValue: 59,
+      },
+      hours: {
+        minValue: 0,
+        maxValue: 23,
+      },
+      daysOfMonth: {
+        minValue: 1,
+        maxValue: 31,
+      },
+      months: {
+        minValue: 1,
+        maxValue: 12,
+      },
+      daysOfWeek: {
+        minValue: 1,
+        maxValue: 7,
+      },
+      years: {
+        minValue: 1970,
+        maxValue: 2199,
+      },
+    }
+  },
+  {
+    name: "npm-cron-schedule",
+    preset: {
+      // https://github.com/P4sca1/cron-schedule
+      presetId: 'npm-cron-schedule',
+      useSeconds: true,
+      useYears: false,
+      useAliases: true,
+      useBlankDay: false,
+      allowOnlyOneBlankDayField: false,
+      mustHaveBlankDayField: false,
+      useLastDayOfMonth: false,
+      useLastDayOfWeek: false,
+      useNearestWeekday: false,
+      useNthWeekdayOfMonth: false,
+      seconds: {
+        minValue: 0,
+        maxValue: 59,
+      },
+      minutes: {
+        minValue: 0,
+        maxValue: 59,
+      },
+      hours: {
+        minValue: 0,
+        maxValue: 23,
+      },
+      daysOfMonth: {
+        minValue: 1,
+        maxValue: 31,
+      },
+      months: {
+        minValue: 1,
+        maxValue: 12,
+      },
+      daysOfWeek: {
+        minValue: 0,
+        maxValue: 7,
+      },
+      years: {
+        minValue: 1970,
+        maxValue: 2099,
+      },
+    }
+  }
+];


### PR DESCRIPTION
This Pull Request addresses https://github.com/Airfooox/cron-validate/issues/81

---

## Foreword

I believe that this Pull Request contains the right ideas to make `cron-validate` perform reasonably fast. However, I am not sure if my implementation aligns with your designs idea @Airfooox 

Thus, please let me know if you disagree with the implementation and we can try to find a better means to integrate the performance improvements into the library.

## Description

This Pull Request introduces two small optimizations that makes `cron-validate` x100 faster when called in a loop. The changes are:
1. Load built-in presets on module load (i.e. "when you import `options`") instead of when calling `validateOptions`. Since the build-in presents do not change, we can load them just once instead of loading them every time that we use `cron()`
2. Introduce a caching mechanism for validated options. If the users invokes `cron()` with the same settings multiple time (defined by preset/presetId and overrides), then we would spend quite a lot of time creating and validating an `Options` object. The creation & validation of this object makes the library about x100 faster when called in a loop.

## Benchmarking

I used this script for benchmarking, using some cron expressions akin to the ones I have been dealing with in production:

```js
import { performance, PerformanceObserver } from 'perf_hooks'
import cronImport from './lib/index.js'

const cron = cronImport.default;

// Helper functions to calculate statistics
function calculateMean(durations) {
  const sum = durations.reduce((a, b) => a + b, 0)
  return sum / durations.length
}

function calculateMedian(durations) {
  const sorted = [...durations].sort((a, b) => a - b)
  const mid = Math.floor(sorted.length / 2)
  return sorted.length % 2 !== 0
    ? sorted[mid]
    : (sorted[mid - 1] + sorted[mid]) / 2
}

function calculateStdDev(durations) {
  const mean = calculateMean(durations)
  const variance =
    durations.reduce((acc, val) => acc + Math.pow(val - mean, 2), 0) /
    durations.length
  return Math.sqrt(variance)
}

// Set up the PerformanceObserver to log performance entries
const obs = new PerformanceObserver(list => {
  const durationsInMicroseconds = performance.getEntriesByType('measure').map(entry => entry .duration * 1_000)

  const mean = calculateMean(durationsInMicroseconds);
  const median = calculateMedian(durationsInMicroseconds);
  const stddev = calculateStdDev(durationsInMicroseconds);

  console.table({
    Samples: durationsInMicroseconds.length,
    Mean: `${mean.toFixed(2)} µs`,
    Median: `${median.toFixed(2)} µs`,
    StdDev: `${stddev.toFixed(2)} µs`,
  });
})

obs.observe({ entryTypes: ['measure'], buffered: true })

const cronExpressions = [
  "0 9 * * MON-FRI",
  "0 22 * * SAT-SUN",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SUN",
  "0 1 * * TUE",
  "0 6 * * MON-FRI",
  "0 20 * * MON-SAT",
  "0 8 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 6 * * MON-FRI",
  "0 19 * * MON-FRI",
  "0 6 * * SAT-SUN",
  "0 1 * * SAT-SUN",
  "0 6 * * MON-FRI",
  "0 20 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 20 * * MON-FRI",
  "0 6 * * SAT-SUN",
  "0 1 * * SAT-SUN",
  "0 6 * * MON-FRI",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 7 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 6 * * *",
  "0 0 * * *",
  "0 20 * * MON-FRI",
  "0 6 * * SAT-SUN",
  "0 1 * * SAT-SUN",
  "0 6 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 0 * * *",
  "0 6 * * *",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 19 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 19 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 19 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 20 * * MON-SAT",
  "0 7 * * MON-SAT",
  "0 5 * * MON-FRI",
  "0 23 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 7 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 7 * * *",
  "0 0 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * SUN",
  "0 0 * * MON",
  "0 19 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 8 * * *",
  "0 20 * * *",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 7 * * *",
  "0 0 * * *",
  "0 6 * * MON-FRI",
  "0 19 * * MON-FRI",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 7 * * *",
  "0 0 * * *",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 8 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "0 6 * * *",
  "0 0 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 18 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 19 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 22 * * SAT-SUN",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SUN",
  "0 1 * * TUE",
  "0 6 * * MON-FRI",
  "0 20 * * MON-SAT",
  "0 8 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 6 * * MON-FRI",
  "0 19 * * MON-FRI",
  "0 6 * * SAT-SUN",
  "0 1 * * SAT-SUN",
  "0 6 * * MON-FRI",
  "0 20 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 20 * * MON-FRI",
  "0 6 * * SAT-SUN",
  "0 1 * * SAT-SUN",
  "0 6 * * MON-FRI",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 7 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 6 * * *",
  "0 0 * * *",
  "0 20 * * MON-FRI",
  "0 6 * * SAT-SUN",
  "0 1 * * SAT-SUN",
  "0 6 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 0 * * *",
  "0 6 * * *",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 19 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 19 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 19 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 20 * * MON-SAT",
  "0 7 * * MON-SAT",
  "0 5 * * MON-FRI",
  "0 23 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 19 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 7 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 7 * * *",
  "0 0 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * SUN",
  "0 0 * * MON",
  "0 19 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 8 * * *",
  "0 20 * * *",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 7 * * *",
  "0 0 * * *",
  "0 6 * * MON-FRI",
  "0 19 * * MON-FRI",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 7 * * *",
  "0 0 * * *",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "50 1 * * SAT",
  "0 1 * * MON",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 8 * * MON-FRI",
  "0 22 * * MON-FRI",
  "0 7 * * MON-FRI",
  "0 18 * * MON-FRI",
  "0 6 * * *",
  "0 0 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 0 * * *",
  "0 6 * * *",
  "0 18 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 6 * * MON-FRI",
  "0 19 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 22 * * SAT-SUN",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 9 * * MON-FRI",
  "0 22 * * SAT-SUN",
]

function validateCronExpressions() {
  for (const expr of cronExpressions) {
    performance.mark('start')
    const result = cron(expr, {
      preset: 'default',
      override: { useAliases: true },
    })
    performance.mark('end')

    if (result.isError()) {
      throw Error('is error!')
    }
    performance.measure('TOTAL TIME', 'start', 'end')
  }
}

validateCronExpressions()
```

To execute the benchmark, first you need to delete the line `"type":"module"` from `package.json`. The output produced by the compiler is CJS, so we cannot import it successfully if we mark the package as ESM. Then, execute the following:

```sh
git checkout $branch
npm run build
node profile.mjs
```

On my machine, these are the results for `next`:
| Metric | Value |
| --- | --- |
| Samples | 400 |
| Mean | 1522.21µs |
| Median | 1316.96 µs |
| StdDev | 670.58 µs |

These are the results for `make-cron-validate-x100-faster`:
| Metric | Value |
| --- | --- |
| Samples | 400 |
| Mean | 26.97µs |
| Median | 12.67 µs |
| StdDev | 215.02 µs |