### PR TITLE
Preserve CommonJS Compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "cron-validate",
   "version": "1.5.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/commit-analyzer": "9.0.2",
+        "@semantic-release/exec": "^7.0.3",
         "@semantic-release/git": "10.0.1",
         "@semantic-release/github": "8.1.0",
         "@semantic-release/release-notes-generator": "10.0.3",
@@ -1336,6 +1337,204 @@
       "dev": true,
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/@semantic-release/exec": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-7.0.3.tgz",
+      "integrity": "sha512-uNWwPNtWi3WTcTm3fWfFQEuj8otOvwoS5m9yo2jSVHuvqdZNsOWmuL0/FqcVyZnCI32fxyYV0G7PPb/TzCH6jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^9.0.0",
+        "lodash-es": "^4.17.21",
+        "parse-json": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.8.1"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=24.1.0"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/execa": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
+      "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.3",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.0",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/human-signals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
+      "integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/parse-json": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
+      "integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "index-to-position": "^0.1.2",
+        "type-fest": "^4.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/type-fest": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.37.0.tgz",
+      "integrity": "sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/git": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "cron-validate is a cron-expression validator written in TypeScript.",
   "scripts": {
     "dev": "nodemon",
-    "build": "tsc",
+    "build": "tsc -p ./tsconfig.build.json",
     "lint": "eslint src/**/*.ts",
     "lint-fix": "eslint src/**/*.ts --fix",
     "prettier": "prettier --write src/**/*.ts",
@@ -77,11 +77,24 @@
           "message": "chore(${branch.name}): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
         }
       ]
+    ],
+    "prepare": [
+      {
+        "path": "@semantic-release/exec",
+        "cmd": "npx tsx scripts/remove-type.ts"
+      }
+    ],
+    "success": [
+      {
+        "path": "@semantic-release/exec",
+        "cmd": "npx tsx scripts/restore-type.ts"
+      }
     ]
   },
   "devDependencies": {
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "9.0.2",
+    "@semantic-release/exec": "^7.0.3",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "8.1.0",
     "@semantic-release/release-notes-generator": "10.0.3",

--- a/scripts/remove-type.ts
+++ b/scripts/remove-type.ts
@@ -1,0 +1,12 @@
+import { readFileSync, writeFileSync } from 'fs'
+
+const packageJsonPath = './package.json'
+
+// Read package.json
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+
+// Remove "type" key for publishing
+delete packageJson.type
+
+// Write back package.json without "type" field
+writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)

--- a/scripts/restore-type.ts
+++ b/scripts/restore-type.ts
@@ -1,0 +1,12 @@
+import { readFileSync, writeFileSync } from 'fs'
+
+const packageJsonPath = './package.json'
+
+// Read current package.json (with new version)
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+
+// Add back the "type" field
+packageJson.type = 'module'
+
+// Write back package.json with "type" field restored
+writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,10 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "rootDir": "src",
-    "outDir": "lib",
     "lib": ["ESNext"],
     "target": "ES2017", // ES2017 is 100% supported in node.js 8.10.0.
     "module": "commonjs", // Node.js does not yet support es-modules.
     "moduleResolution": "node",
-
     "declaration": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -15,6 +12,6 @@
     "noFallthroughCasesInSwitch": true,
     "importsNotUsedAsValues": "preserve"
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "scripts/**/*.ts"],
   "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
# Preserve CommonJS Compatibility

## Issue

Version 1.5.0 introduced `"type": "module"` in package.json, which changed the module system from CommonJS to ESM. While this is great for modern development, it created a breaking change for:

1. Users who use ESM syntax but build to CommonJS output, particularly in projects using TypeScript or other transpilers
2. Legacy projects that rely on CommonJS imports and cannot easily migrate to ESM

The issue manifests when users try to import the package in a project that builds to CommonJS:

```js
// This fails after v1.5.0 when building to CommonJS
import cron from 'cron-validate'
```

This results in the following error:

```bash
ERROR: Error [ERR_REQUIRE_ESM]: require() of ES Module [...]/node_modules/cron-validate/lib/index.js not supported.
index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in [...]/node_modules/cron-validate/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```

For many projects, especially those supporting mixed module syntax but building to CommonJS, this creates a significant breaking change that can't be easily addressed without major refactoring.

## Solution

This PR implements a solution that allows the project to use ESM during development while ensuring the published package remains compatible with CommonJS. This is achieved by:

1. Keeping `"type": "module"` in the repository for development
2. Removing this field before publishing to npm
3. Restoring the field after publishing

### Why This Approach?

I noticed that the project's TypeScript configuration already targets CommonJS output:

```json
// tsconfig.json
{
  "compilerOptions": {
    "module": "commonjs" // Outputs CommonJS modules
    // ...
  }
}
```

This means the compiled JavaScript files in the `lib` directory are already in CommonJS format. The only reason they're treated as ESM is because of the `"type": "module"` field in package.json.

By removing this field during publishing, we allow the compiled CommonJS files to be consumed as intended, without changing how the project is developed or built. This is the least invasive approach that maintains compatibility with both:

- Modern development using ESM
- Existing consumers who expect CommonJS compatibility

## Implementation Details

### 1. Semantic Release Hooks

Added two semantic-release hooks:

- **prepare**: Removes the `"type": "module"` field before publishing

  ```json
  "prepare": [
    {
      "path": "@semantic-release/exec",
      "cmd": "npx tsx scripts/remove-type.ts"
    }
  ]
  ```

- **success**: Restores the `"type": "module"` field after publishing

  ```json
  "success": [
    {
      "path": "@semantic-release/exec",
      "cmd": "npx tsx scripts/restore-type.ts"
    }
  ]
  ```

### 2. TypeScript Scripts

Created two scripts to handle the modification of package.json:

- **scripts/remove-type.ts**: Removes the `"type"` field before publishing
- **scripts/restore-type.ts**: Adds back the `"type": "module"` field after publishing

### 3. Build Configuration

Added a dedicated `tsconfig.build.json` for the build process, separating build settings from development settings. This ensures that the utility scripts in the `scripts` folder are not included in the build output, keeping the published package clean and focused only on the core functionality.

### 4. Dependencies

Added `@semantic-release/exec` as a development dependency to enable running the scripts during the semantic-release process.

## Flow Explanation

Here's how the solution works during the release process:

1. **Development**: Developers work with ESM enabled (`"type": "module"` in package.json)
2. **Release Initiated**: When running `npm run release`, semantic-release starts the process
3. **Prepare Phase**: The `remove-type.ts` script runs, removing `"type": "module"` from package.json
4. **Publishing**: The package is published to npm without the `"type"` field, making it CommonJS compatible
5. **Success Phase**: After successful publishing, the `restore-type.ts` script runs, adding back `"type": "module"` to package.json
6. **Git Commit**: semantic-release commits the changes to Git, with the `"type": "module"` field restored

This approach ensures:

- The published package is CommonJS compatible
- The Git repository maintains ESM support for development
- The process is transparent to both developers and users

## Benefits

This approach:

- Maintains backward compatibility with existing users
- Allows developers to use modern ESM features
- Integrates seamlessly with the existing semantic-release workflow
- Requires minimal changes to the codebase
